### PR TITLE
Fix sidebar role filtering and add cell report attendance

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { useLocation, NavLink } from 'react-router-dom';
+import { UserRole } from '@/types/auth';
 import {
   Home,
   Users,
@@ -22,7 +23,6 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar';
-import logoVideira from '@/assets/logo-videira.png';
 
 interface NavigationItem {
   title: string;
@@ -85,8 +85,9 @@ export function Sidebar() {
 
   const collapsed = state === "collapsed";
 
-  const filteredItems = navigationItems.filter(item => 
-    item.roles.includes(user.role)
+  const userRole = (user.role || '').toLowerCase() as UserRole;
+  const filteredItems = navigationItems.filter(item =>
+    item.roles.includes(userRole)
   );
 
   const isActive = (path: string) => location.pathname === path;

--- a/src/pages/CellManagement.tsx
+++ b/src/pages/CellManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -44,14 +44,25 @@ export function CellManagement() {
     type: 'member' as 'member' | 'frequentador',
   });
 
-  // Load members on component mount
+  // Load members and subscribe to changes
   useEffect(() => {
     if (user && user.role === 'lider') {
       loadMembers();
-    }
-  }, [user]);
 
-  const loadMembers = async () => {
+      const channel = supabase
+        .channel('members_changes')
+        .on('postgres_changes', { event: '*', schema: 'public', table: 'members', filter: `lider_id=eq.${user.id}` }, () => {
+          loadMembers();
+        })
+        .subscribe();
+
+      return () => {
+        supabase.removeChannel(channel);
+      };
+    }
+  }, [user, loadMembers]);
+
+  const loadMembers = useCallback(async () => {
     if (!user) return;
     
     const { data, error } = await supabase
@@ -79,7 +90,7 @@ export function CellManagement() {
     }));
 
     setMembers(formattedMembers);
-  };
+  }, [user]);
 
   if (!user || user.role !== 'lider') {
     return (
@@ -111,19 +122,8 @@ export function CellManagement() {
       return;
     }
 
-    // Add to local state
-    const newMemberData: Member = {
-      id: data.id,
-      name: data.name,
-      phone: data.phone,
-      email: data.email,
-      type: data.type as 'member' | 'frequentador',
-      liderId: data.lider_id,
-      joinDate: new Date(data.join_date),
-      active: data.active,
-    };
-
-    setMembers([newMemberData, ...members]);
+    // Reload members to reflect new entry
+    await loadMembers();
     setNewMember({ name: '', phone: '', email: '', type: 'member' });
     setIsAddDialogOpen(false);
   };

--- a/src/pages/CellReports.tsx
+++ b/src/pages/CellReports.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import { 
   Dialog, 
   DialogContent, 
@@ -23,17 +24,13 @@ import {
   TableHeader, 
   TableRow 
 } from '@/components/ui/table';
-import { 
-  FileText, 
-  Plus, 
-  Send, 
-  Calendar,
-  Users,
-  CheckCircle,
-  Clock,
-  AlertCircle
+import {
+  FileText,
+  Plus,
+  Calendar
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { Member } from '@/types/church';
 
 interface CellReport {
   id: string;
@@ -43,6 +40,8 @@ interface CellReport {
   observations?: string;
   status: 'draft' | 'submitted' | 'approved';
   submittedAt: Date;
+  membersPresent: string[];
+  visitorsPresent: string[];
 }
 
 export function CellReports() {
@@ -54,14 +53,38 @@ export function CellReports() {
   const [multiplicationDate, setMultiplicationDate] = useState('');
   const [observations, setObservations] = useState('');
   const [loading, setLoading] = useState(true);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [frequentadores, setFrequentadores] = useState<Member[]>([]);
+  const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+  const [selectedVisitors, setSelectedVisitors] = useState<string[]>([]);
 
   useEffect(() => {
     if (user && user.role === 'lider') {
+      loadMembers();
       loadReports();
-    }
-  }, [user]);
 
-  const loadReports = async () => {
+      const reportsChannel = supabase
+        .channel('cell_reports_changes')
+        .on('postgres_changes', { event: '*', schema: 'public', table: 'cell_reports', filter: `lider_id=eq.${user.id}` }, () => {
+          loadReports();
+        })
+        .subscribe();
+
+      const membersChannel = supabase
+        .channel('members_for_reports')
+        .on('postgres_changes', { event: '*', schema: 'public', table: 'members', filter: `lider_id=eq.${user.id}` }, () => {
+          loadMembers();
+        })
+        .subscribe();
+
+      return () => {
+        supabase.removeChannel(reportsChannel);
+        supabase.removeChannel(membersChannel);
+      };
+    }
+  }, [user, loadMembers, loadReports]);
+
+  const loadReports = useCallback(async () => {
     if (!user) return;
     
     const { data, error } = await supabase
@@ -84,11 +107,41 @@ export function CellReports() {
       observations: report.observations,
       status: report.status as 'draft' | 'submitted' | 'approved',
       submittedAt: new Date(report.submitted_at),
+      membersPresent: report.members_present || [],
+      visitorsPresent: report.frequentadores_present || [],
     }));
 
     setReports(formattedReports);
     setLoading(false);
-  };
+  }, [user]);
+
+  const loadMembers = useCallback(async () => {
+    if (!user) return;
+
+    const { data, error } = await supabase
+      .from('members')
+      .select('id, name, type')
+      .eq('lider_id', user.id)
+      .eq('active', true)
+      .order('name');
+
+    if (error) {
+      console.error('Error loading members:', error);
+      return;
+    }
+
+    const memberList: Member[] = (data || []).map(m => ({
+      id: m.id,
+      name: m.name,
+      type: m.type as 'member' | 'frequentador',
+      liderId: user.id,
+      joinDate: new Date(),
+      active: true,
+    }));
+
+    setMembers(memberList.filter(m => m.type === 'member'));
+    setFrequentadores(memberList.filter(m => m.type === 'frequentador'));
+  }, [user]);
 
   if (!user || user.role !== 'lider') {
     return (
@@ -111,6 +164,8 @@ export function CellReports() {
           multiplication_date: multiplicationDate || null,
           observations: observations || null,
           status: 'draft',
+          members_present: selectedMembers,
+          frequentadores_present: selectedVisitors,
         }
       ])
       .select()
@@ -130,6 +185,8 @@ export function CellReports() {
     setSelectedMonth('');
     setMultiplicationDate('');
     setObservations('');
+    setSelectedMembers([]);
+    setSelectedVisitors([]);
     
     toast({
       title: "Sucesso",
@@ -214,6 +271,48 @@ export function CellReports() {
                   rows={3}
                 />
               </div>
+              <div>
+                <Label>Membros Presentes</Label>
+                <div className="max-h-32 overflow-y-auto space-y-2 mt-2">
+                  {members.map((m) => (
+                    <div key={m.id} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={`member-${m.id}`}
+                        checked={selectedMembers.includes(m.id)}
+                        onCheckedChange={(checked) => {
+                          setSelectedMembers(prev =>
+                            checked ? [...prev, m.id] : prev.filter(id => id !== m.id)
+                          );
+                        }}
+                      />
+                      <Label htmlFor={`member-${m.id}`} className="text-sm font-normal">
+                        {m.name}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <Label>Frequentadores Presentes</Label>
+                <div className="max-h-32 overflow-y-auto space-y-2 mt-2">
+                  {frequentadores.map((m) => (
+                    <div key={m.id} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={`visitor-${m.id}`}
+                        checked={selectedVisitors.includes(m.id)}
+                        onCheckedChange={(checked) => {
+                          setSelectedVisitors(prev =>
+                            checked ? [...prev, m.id] : prev.filter(id => id !== m.id)
+                          );
+                        }}
+                      />
+                      <Label htmlFor={`visitor-${m.id}`} className="text-sm font-normal">
+                        {m.name}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              </div>
               <Button onClick={handleCreateReport} className="w-full gradient-primary">
                 Criar Relatório
               </Button>
@@ -241,6 +340,8 @@ export function CellReports() {
                 <TableRow>
                   <TableHead>Período</TableHead>
                   <TableHead>Status</TableHead>
+                  <TableHead>Membros</TableHead>
+                  <TableHead>Frequentadores</TableHead>
                   <TableHead>Data de Multiplicação</TableHead>
                   <TableHead>Data de Envio</TableHead>
                 </TableRow>
@@ -256,6 +357,8 @@ export function CellReports() {
                         {report.status === 'draft' ? 'Rascunho' : report.status === 'submitted' ? 'Enviado' : 'Aprovado'}
                       </Badge>
                     </TableCell>
+                    <TableCell>{report.membersPresent.length}</TableCell>
+                    <TableCell>{report.visitorsPresent.length}</TableCell>
                     <TableCell>
                       {report.multiplicationDate ? (
                         <div className="flex items-center gap-1 text-sm">

--- a/src/types/church.ts
+++ b/src/types/church.ts
@@ -15,8 +15,8 @@ export interface CellReport {
   liderId: string;
   month: string; // YYYY-MM
   year: number;
-  members: Member[];
-  frequentadores: Member[];
+  membersPresent: string[];
+  visitorsPresent: string[];
   multiplicationDate?: Date;
   observations?: string;
   submittedAt: Date;

--- a/supabase/migrations/20250915120000_add_attendance_to_cell_reports.sql
+++ b/supabase/migrations/20250915120000_add_attendance_to_cell_reports.sql
@@ -1,0 +1,4 @@
+-- Add attendance arrays to cell_reports
+ALTER TABLE public.cell_reports
+  ADD COLUMN IF NOT EXISTS members_present UUID[] DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS frequentadores_present UUID[] DEFAULT '{}';


### PR DESCRIPTION
## Summary
- show sidebar navigation based on normalized user role
- add attendance tracking for members and visitors in cell reports
- enable realtime updates for cell reports and cell members

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c4997c7ff0832886d3d5787f2711f0