### PR TITLE
feat: pastor discipulador management and reporting tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { CellManagement } from "@/pages/CellManagement";
 import { CourseRegistration } from "@/pages/CourseRegistration";
 import { CellReports } from "@/pages/CellReports";
 import { LeaderManagement } from "@/pages/LeaderManagement";
+import { DiscipuladorManagement } from "@/pages/DiscipuladorManagement";
 import { NetworkReports } from "@/pages/NetworkReports";
 import { Statistics } from "@/pages/Statistics";
 import NotFound from "./pages/NotFound";
@@ -69,6 +70,7 @@ function AppContent() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/celula" element={<CellManagement />} />
         <Route path="/lideres" element={<LeaderManagement />} />
+        <Route path="/discipuladores" element={<DiscipuladorManagement />} />
         <Route path="/relatorios" element={<ReportsRouter />} />
         <Route path="/cursos" element={<CourseRegistration />} />
         <Route path="/eventos" element={<div>Eventos (Em breve)</div>} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -51,6 +51,12 @@ const navigationItems: NavigationItem[] = [
     roles: ['discipulador'],
   },
   {
+    title: 'Meus Discipuladores',
+    url: '/discipuladores',
+    icon: Users,
+    roles: ['pastor'],
+  },
+  {
     title: 'Relatórios de Célula',
     url: '/relatorios',
     icon: FileText,

--- a/src/pages/DiscipuladorManagement.tsx
+++ b/src/pages/DiscipuladorManagement.tsx
@@ -1,0 +1,252 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { supabaseAdmin } from '@/integrations/supabase/admin';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Users, Plus, Phone, Mail } from 'lucide-react';
+import { Discipulador } from '@/types/church';
+
+export function DiscipuladorManagement() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [discipuladores, setDiscipuladores] = useState<Discipulador[]>([]);
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [newDiscipulador, setNewDiscipulador] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    password: '',
+  });
+
+  useEffect(() => {
+    if (user && user.role === 'pastor') {
+      loadDiscipuladores();
+    }
+  }, [user]);
+
+  const loadDiscipuladores = async () => {
+    if (!user) return;
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, name, email, phone, created_at')
+      .eq('pastor_uuid', user.id)
+      .eq('role', 'discipulador')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Error loading discipuladores:', error);
+      return;
+    }
+
+    const formatted: Discipulador[] = (data || []).map((d) => ({
+      id: d.id,
+      name: d.name,
+      email: d.email,
+      phone: d.phone || undefined,
+      pastorId: user.id,
+      createdAt: new Date(d.created_at),
+    }));
+    setDiscipuladores(formatted);
+  };
+
+  if (!user || user.role !== 'pastor') {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Acesso restrito para pastores.</p>
+      </div>
+    );
+  }
+
+  const handleAddDiscipulador = async () => {
+    if (!user) return;
+
+    const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
+      email: newDiscipulador.email,
+      password: newDiscipulador.password,
+      email_confirm: true,
+      user_metadata: { name: newDiscipulador.name, phone: newDiscipulador.phone },
+    });
+
+    if (authError || !authData.user) {
+      console.error('Error creating discipulador user:', authError);
+      toast({
+        title: 'Erro',
+        description: 'Falha ao criar usuário do discipulador.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const profilePayload = {
+      user_id: authData.user.id,
+      name: newDiscipulador.name,
+      email: newDiscipulador.email,
+      phone: newDiscipulador.phone || null,
+      discipulador_uuid: null,
+      pastor_uuid: user.id,
+      role: 'discipulador' as const,
+    };
+
+    let profileId: string | null = null;
+
+    const { data: insertData, error: insertError } = await supabaseAdmin
+      .from('profiles')
+      .insert(profilePayload)
+      .select('id')
+      .single();
+
+    if (insertError && insertError.code === '23505') {
+      const { data: updateData, error: updateError } = await supabaseAdmin
+        .from('profiles')
+        .update(profilePayload)
+        .eq('user_id', authData.user.id)
+        .select('id')
+        .single();
+
+      if (updateError || !updateData) {
+        console.error('Error updating profile:', updateError);
+        toast({
+          title: 'Erro',
+          description: 'Não foi possível salvar o perfil do discipulador.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      profileId = updateData.id;
+    } else if (insertError || !insertData) {
+      console.error('Error inserting profile:', insertError);
+      toast({
+        title: 'Erro',
+        description: 'Não foi possível salvar o perfil do discipulador.',
+        variant: 'destructive',
+      });
+      return;
+    } else {
+      profileId = insertData.id;
+    }
+
+    const discipuladorData: Discipulador = {
+      id: profileId,
+      name: newDiscipulador.name,
+      email: newDiscipulador.email,
+      phone: newDiscipulador.phone || undefined,
+      pastorId: user.id,
+      createdAt: new Date(),
+    };
+
+    setDiscipuladores([discipuladorData, ...discipuladores]);
+    await loadDiscipuladores();
+    setIsAddDialogOpen(false);
+    setNewDiscipulador({ name: '', email: '', phone: '', password: '' });
+    toast({ title: 'Sucesso', description: 'Discipulador cadastrado com sucesso!' });
+  };
+
+  return (
+    <div className="space-y-8 animate-fade-in">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-foreground">Meus Discipuladores</h1>
+        <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+          <DialogTrigger asChild>
+            <Button className="gradient-primary">
+              <Plus className="w-4 h-4 mr-2" />
+              Novo Discipulador
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Adicionar Discipulador</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Nome</Label>
+                <Input
+                  id="name"
+                  value={newDiscipulador.name}
+                  onChange={(e) => setNewDiscipulador({ ...newDiscipulador, name: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={newDiscipulador.email}
+                  onChange={(e) => setNewDiscipulador({ ...newDiscipulador, email: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phone">Telefone</Label>
+                <Input
+                  id="phone"
+                  value={newDiscipulador.phone}
+                  onChange={(e) => setNewDiscipulador({ ...newDiscipulador, phone: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Senha Inicial</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={newDiscipulador.password}
+                  onChange={(e) => setNewDiscipulador({ ...newDiscipulador, password: e.target.value })}
+                />
+              </div>
+              <Button onClick={handleAddDiscipulador} className="w-full gradient-primary">
+                Adicionar
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="w-5 h-5 text-primary" />
+            Lista de Discipuladores
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Telefone</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {discipuladores.map((d) => (
+                <TableRow key={d.id}>
+                  <TableCell className="font-medium">{d.name}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1 text-sm">
+                      <Mail className="w-3 h-3" />
+                      {d.email}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {d.phone && (
+                      <div className="flex items-center gap-1 text-sm">
+                        <Phone className="w-3 h-3" />
+                        {d.phone}
+                      </div>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/pages/NetworkReports.tsx
+++ b/src/pages/NetworkReports.tsx
@@ -10,7 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { FileText, Calendar, CheckCircle2, XCircle, Download } from 'lucide-react';
 import * as XLSX from 'xlsx';
-import { Leader, CellReport as CellReportType } from '@/types/church';
+import { Leader, Discipulador, CellReport as CellReportType } from '@/types/church';
 import { useToast } from '@/hooks/use-toast';
 
 export function NetworkReports() {
@@ -20,16 +20,47 @@ export function NetworkReports() {
   const [selectedLeader, setSelectedLeader] = useState('');
   const [reports, setReports] = useState<CellReportType[]>([]);
   const [networkReports, setNetworkReports] = useState<CellReportType[]>([]);
+  const [discipuladores, setDiscipuladores] = useState<Discipulador[]>([]);
+  const [selectedDiscipulador, setSelectedDiscipulador] = useState('');
+  const [churchReports, setChurchReports] = useState<CellReportType[]>([]);
   const [chartMode, setChartMode] = useState<'mensal' | 'semanal'>('mensal');
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (user && (user.role === 'discipulador' || user.role === 'pastor')) {
+      if (user.role === 'pastor') {
+        loadDiscipuladores();
+      }
       loadLeaders();
     } else {
       setLoading(false);
     }
   }, [user]);
+
+  const loadDiscipuladores = async () => {
+    if (!user) return;
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, name, email, phone, created_at')
+      .eq('pastor_uuid', user.id)
+      .eq('role', 'discipulador')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Error loading discipuladores:', error);
+      return;
+    }
+
+    const formatted: Discipulador[] = (data || []).map((d) => ({
+      id: d.id,
+      name: d.name,
+      email: d.email,
+      phone: d.phone || undefined,
+      pastorId: user.id,
+      createdAt: new Date(d.created_at),
+    }));
+    setDiscipuladores(formatted);
+  };
 
   const loadLeaders = async () => {
     if (!user) return;
@@ -60,7 +91,10 @@ export function NetworkReports() {
       createdAt: new Date(),
     }));
     setLeaders(formatted);
-    await loadNetworkReports(formatted.map((l) => l.id));
+    await loadReportsForLeaders(
+      formatted.map((l) => l.id),
+      user.role === 'pastor' ? setChurchReports : setNetworkReports
+    );
     setLoading(false);
   };
 
@@ -69,6 +103,15 @@ export function NetworkReports() {
       loadReports();
     }
   }, [selectedLeader]);
+
+  useEffect(() => {
+    if (user?.role === 'pastor' && selectedDiscipulador) {
+      const leaderIds = leaders
+        .filter((l) => l.discipuladorId === selectedDiscipulador)
+        .map((l) => l.id);
+      loadReportsForLeaders(leaderIds, setNetworkReports);
+    }
+  }, [selectedDiscipulador, leaders, user]);
 
   const loadReports = async () => {
     const { data, error } = await supabase
@@ -109,8 +152,14 @@ export function NetworkReports() {
     setReports(formatted);
   };
 
-  const loadNetworkReports = async (leaderIds: string[]) => {
-    if (leaderIds.length === 0) return;
+  const loadReportsForLeaders = async (
+    leaderIds: string[],
+    setter: React.Dispatch<React.SetStateAction<CellReportType[]>>
+  ) => {
+    if (leaderIds.length === 0) {
+      setter([]);
+      return;
+    }
     const { data, error } = await supabase
       .from('cell_reports')
       .select('*')
@@ -146,7 +195,7 @@ export function NetworkReports() {
       submittedAt: new Date(r.submitted_at),
       status: r.status as 'draft' | 'submitted' | 'approved' | 'needs_correction',
     }));
-    setNetworkReports(formatted);
+    setter(formatted);
   };
 
   const chartData = useMemo(() => {
@@ -195,6 +244,44 @@ export function NetworkReports() {
     }));
   }, [networkReports, chartMode]);
 
+  const churchChartData = useMemo(() => {
+    if (chartMode === 'mensal') {
+      const groups: Record<string, { members: number; frequentadores: number }> = {};
+      churchReports.forEach((r) => {
+        const key = `${r.weekStart.getFullYear()}-${r.weekStart.getMonth() + 1}`;
+        if (!groups[key]) {
+          groups[key] = { members: 0, frequentadores: 0 };
+        }
+        groups[key].members += r.members.length;
+        groups[key].frequentadores += r.frequentadores.length;
+      });
+      return Object.entries(groups).map(([key, value]) => {
+        const [year, month] = key.split('-');
+        return { name: `${month}/${year}`, ...value };
+      });
+    }
+    return churchReports.map((r) => ({
+      name: r.weekStart.toLocaleDateString('pt-BR'),
+      members: r.members.length,
+      frequentadores: r.frequentadores.length,
+    }));
+  }, [churchReports, chartMode]);
+
+  const handleExportChurch = () => {
+    const data = churchReports.map((r) => ({
+      Semana: r.weekStart.toLocaleDateString('pt-BR'),
+      Lider: leaders.find((l) => l.id === r.liderId)?.name || r.liderId,
+      Fase: r.phase,
+      Membros: r.members.length,
+      Frequentadores: r.frequentadores.length,
+      Status: r.status,
+    }));
+    const ws = XLSX.utils.json_to_sheet(data);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Relatorios');
+    XLSX.writeFile(wb, 'relatorios-igreja.xlsx');
+  };
+
   const handleExportNetwork = () => {
     const data = networkReports.map((r) => ({
       Semana: r.weekStart.toLocaleDateString('pt-BR'),
@@ -225,6 +312,7 @@ export function NetworkReports() {
     }
     setReports((prev) => prev.map((r) => (r.id === id ? { ...r, status: 'approved' } : r)));
     setNetworkReports((prev) => prev.map((r) => (r.id === id ? { ...r, status: 'approved' } : r)));
+    setChurchReports((prev) => prev.map((r) => (r.id === id ? { ...r, status: 'approved' } : r)));
     toast({ title: 'Relatório aprovado!' });
   };
 
@@ -247,6 +335,9 @@ export function NetworkReports() {
     setNetworkReports((prev) =>
       prev.map((r) => (r.id === report.id ? { ...r, status: 'needs_correction' } : r))
     );
+    setChurchReports((prev) =>
+      prev.map((r) => (r.id === report.id ? { ...r, status: 'needs_correction' } : r))
+    );
     await supabase.from('notifications').insert({
       user_id: report.liderId,
       message: `Seu relatório da semana ${report.weekStart.toLocaleDateString('pt-BR')} precisa de correção.`,
@@ -267,6 +358,288 @@ export function NetworkReports() {
       <div className="flex items-center justify-center py-12">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
+    );
+  }
+  if (user.role === 'pastor') {
+    return (
+      <Tabs defaultValue="church" className="space-y-8 animate-fade-in">
+        <TabsList>
+          <TabsTrigger value="church">Igreja</TabsTrigger>
+          <TabsTrigger value="networks">Redes</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="church">
+          <div className="space-y-8">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <h1 className="text-3xl font-bold text-foreground">Relatório da Igreja</h1>
+              <div className="flex gap-4">
+                <Select value={chartMode} onValueChange={(v) => setChartMode(v as 'mensal' | 'semanal')}>
+                  <SelectTrigger className="w-[150px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mensal">Mensal</SelectItem>
+                    <SelectItem value="semanal">Semanal</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button size="sm" className="flex items-center gap-1" onClick={handleExportChurch}>
+                  <Download className="w-4 h-4" /> Excel
+                </Button>
+              </div>
+            </div>
+
+            <Card className="hover:grape-glow transition-smooth">
+              <CardHeader>
+                <CardTitle>Resumo</CardTitle>
+              </CardHeader>
+              <CardContent className="h-[300px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={churchChartData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="name" />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend />
+                    <Line type="monotone" dataKey="members" name="Membros" stroke="#8884d8" />
+                    <Line type="monotone" dataKey="frequentadores" name="Frequentadores" stroke="#82ca9d" />
+                  </LineChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <FileText className="w-5 h-5 text-primary" />
+                  Relatórios
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {churchReports.length === 0 ? (
+                  <div className="text-center py-8">
+                    <FileText className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+                    <p className="text-muted-foreground">Nenhum relatório encontrado.</p>
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Líder</TableHead>
+                        <TableHead>Semana</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Fase</TableHead>
+                        <TableHead>Data de Multiplicação</TableHead>
+                        <TableHead>Data de Envio</TableHead>
+                        <TableHead className="text-right">Ações</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {churchReports.map((r) => (
+                        <TableRow key={r.id}>
+                          <TableCell className="font-medium">
+                            {leaders.find((l) => l.id === r.liderId)?.name || r.liderId}
+                          </TableCell>
+                          <TableCell>{r.weekStart.toLocaleDateString('pt-BR')}</TableCell>
+                          <TableCell>
+                            <Badge variant={r.status === 'approved' ? 'default' : r.status === 'needs_correction' ? 'destructive' : 'secondary'}>
+                              {r.status === 'submitted'
+                                ? 'Enviado'
+                                : r.status === 'approved'
+                                ? 'Aprovado'
+                                : r.status === 'needs_correction'
+                                ? 'Correção'
+                                : 'Rascunho'}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>{r.phase}</TableCell>
+                          <TableCell>
+                            {r.multiplicationDate ? (
+                              <div className="flex items-center gap-1 text-sm">
+                                <Calendar className="w-3 h-3" />
+                                {r.multiplicationDate.toLocaleDateString('pt-BR')}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-1 text-sm">
+                              <Calendar className="w-3 h-3" />
+                              {r.submittedAt.toLocaleDateString('pt-BR')}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right space-x-2">
+                            {r.status === 'submitted' && (
+                              <>
+                                <Button size="sm" className="inline-flex items-center gap-1" onClick={() => handleApprove(r.id)}>
+                                  <CheckCircle2 className="w-4 h-4" /> Aprovar
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="secondary"
+                                  className="inline-flex items-center gap-1"
+                                  onClick={() => handleRequestCorrection(r)}
+                                >
+                                  <XCircle className="w-4 h-4" /> Correção
+                                </Button>
+                              </>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="networks">
+          <div className="space-y-8">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <h1 className="text-3xl font-bold text-foreground">Relatórios das Redes</h1>
+              <div className="flex gap-4">
+                <Select value={selectedDiscipulador} onValueChange={setSelectedDiscipulador}>
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue placeholder="Selecione um discipulador" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {discipuladores.map((d) => (
+                      <SelectItem key={d.id} value={d.id}>
+                        {d.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value={chartMode} onValueChange={(v) => setChartMode(v as 'mensal' | 'semanal')}>
+                  <SelectTrigger className="w-[150px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mensal">Mensal</SelectItem>
+                    <SelectItem value="semanal">Semanal</SelectItem>
+                  </SelectContent>
+                </Select>
+                {selectedDiscipulador && (
+                  <Button size="sm" className="flex items-center gap-1" onClick={handleExportNetwork}>
+                    <Download className="w-4 h-4" /> Excel
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {selectedDiscipulador && (
+              <>
+                <Card className="hover:grape-glow transition-smooth">
+                  <CardHeader>
+                    <CardTitle>Resumo</CardTitle>
+                  </CardHeader>
+                  <CardContent className="h-[300px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={networkChartData}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="name" />
+                        <YAxis />
+                        <Tooltip />
+                        <Legend />
+                        <Line type="monotone" dataKey="members" name="Membros" stroke="#8884d8" />
+                        <Line type="monotone" dataKey="frequentadores" name="Frequentadores" stroke="#82ca9d" />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <FileText className="w-5 h-5 text-primary" />
+                      Relatórios
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {networkReports.length === 0 ? (
+                      <div className="text-center py-8">
+                        <FileText className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+                        <p className="text-muted-foreground">Nenhum relatório encontrado.</p>
+                      </div>
+                    ) : (
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Líder</TableHead>
+                            <TableHead>Semana</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead>Fase</TableHead>
+                            <TableHead>Data de Multiplicação</TableHead>
+                            <TableHead>Data de Envio</TableHead>
+                            <TableHead className="text-right">Ações</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {networkReports.map((r) => (
+                            <TableRow key={r.id}>
+                              <TableCell className="font-medium">
+                                {leaders.find((l) => l.id === r.liderId)?.name || r.liderId}
+                              </TableCell>
+                              <TableCell>{r.weekStart.toLocaleDateString('pt-BR')}</TableCell>
+                              <TableCell>
+                                <Badge variant={r.status === 'approved' ? 'default' : r.status === 'needs_correction' ? 'destructive' : 'secondary'}>
+                                  {r.status === 'submitted'
+                                    ? 'Enviado'
+                                    : r.status === 'approved'
+                                    ? 'Aprovado'
+                                    : r.status === 'needs_correction'
+                                    ? 'Correção'
+                                    : 'Rascunho'}
+                                </Badge>
+                              </TableCell>
+                              <TableCell>{r.phase}</TableCell>
+                              <TableCell>
+                                {r.multiplicationDate ? (
+                                  <div className="flex items-center gap-1 text-sm">
+                                    <Calendar className="w-3 h-3" />
+                                    {r.multiplicationDate.toLocaleDateString('pt-BR')}
+                                  </div>
+                                ) : (
+                                  <span className="text-muted-foreground">-</span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <div className="flex items-center gap-1 text-sm">
+                                  <Calendar className="w-3 h-3" />
+                                  {r.submittedAt.toLocaleDateString('pt-BR')}
+                                </div>
+                              </TableCell>
+                              <TableCell className="text-right space-x-2">
+                                {r.status === 'submitted' && (
+                                  <>
+                                    <Button size="sm" className="inline-flex items-center gap-1" onClick={() => handleApprove(r.id)}>
+                                      <CheckCircle2 className="w-4 h-4" /> Aprovar
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      variant="secondary"
+                                      className="inline-flex items-center gap-1"
+                                      onClick={() => handleRequestCorrection(r)}
+                                    >
+                                      <XCircle className="w-4 h-4" /> Correção
+                                    </Button>
+                                  </>
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    )}
+                  </CardContent>
+                </Card>
+              </>
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
     );
   }
 
@@ -421,49 +794,47 @@ export function NetworkReports() {
       </TabsContent>
 
       <TabsContent value="network">
-  <div className="space-y-8">
-    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-      <h1 className="text-3xl font-bold text-foreground">Relatório da Rede</h1>
-      <div className="flex gap-4">
-        <Select value={chartMode} onValueChange={(v) => setChartMode(v as 'mensal' | 'semanal')}>
-          <SelectTrigger className="w-[150px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="mensal">Mensal</SelectItem>
-            <SelectItem value="semanal">Semanal</SelectItem>
-          </SelectContent>
-        </Select>
-        <Button size="sm" className="flex items-center gap-1" onClick={handleExportNetwork}>
-          <Download className="w-4 h-4" /> Excel
-        </Button>
-      </div>
-    </div>
+        <div className="space-y-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <h1 className="text-3xl font-bold text-foreground">Relatório da Rede</h1>
+            <div className="flex gap-4">
+              <Select value={chartMode} onValueChange={(v) => setChartMode(v as 'mensal' | 'semanal')}>
+                <SelectTrigger className="w-[150px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="mensal">Mensal</SelectItem>
+                  <SelectItem value="semanal">Semanal</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button size="sm" className="flex items-center gap-1" onClick={handleExportNetwork}>
+                <Download className="w-4 h-4" /> Excel
+              </Button>
+            </div>
+          </div>
 
-    {/* Resumo (gráfico) da Rede */}
-    <Card className="hover:grape-glow transition-smooth">
-      <CardHeader>
-        <CardTitle>Resumo</CardTitle>
-      </CardHeader>
-      <CardContent className="h-[300px]">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={networkChartData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" />
-            <YAxis />
-            <Tooltip />
-            <Legend />
-            <Line type="monotone" dataKey="members" name="Membros" stroke="#8884d8" />
-            <Line type="monotone" dataKey="frequentadores" name="Frequentadores" stroke="#82ca9d" />
-          </LineChart>
-        </ResponsiveContainer>
-      </CardContent>
-    </Card>
+          <Card className="hover:grape-glow transition-smooth">
+            <CardHeader>
+              <CardTitle>Resumo</CardTitle>
+            </CardHeader>
+            <CardContent className="h-[300px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={networkChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Line type="monotone" dataKey="members" name="Membros" stroke="#8884d8" />
+                  <Line type="monotone" dataKey="frequentadores" name="Frequentadores" stroke="#82ca9d" />
+                </LineChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
 
-    {/* 🔕 Removido: Card com a tabela de Relatórios na visão "Rede" */}
-  </div>
-</TabsContent>
-
+          {/* 🔕 Removido: Card com a tabela de Relatórios na visão "Rede" */}
+        </div>
+      </TabsContent>
     </Tabs>
   );
 }

--- a/src/types/church.ts
+++ b/src/types/church.ts
@@ -8,6 +8,15 @@ export interface Leader {
   createdAt: Date;
 }
 
+export interface Discipulador {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  pastorId: string;
+  createdAt: Date;
+}
+
 export interface Member {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- allow pastors to create and manage discipuladores
- add church and network tabs with discipulador reports for pastors
- expose discipulador management in sidebar and routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7023a34f48328b5dfc4efece14dd1