### PR TITLE
feat: add fancy loaders and mobile responsive tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,11 +41,11 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   if (showLoader) {
     return (
       <FancyLoader
-        message="Carregando dados…"
+        message="Colhendo os frutos do seu painel"
         tips={[
-          "Conferindo conexões…",
-          "Atualizando informações…",
-          "Organizando a visualização…",
+          "Azeitando as engrenagens do templo digital…",
+          "Conferindo se o maná dos relatórios já caiu…",
+          "Separando pão e peixe pra alimentar os gráficos…",
         ]}
       />
     );
@@ -62,11 +62,11 @@ function PublicRoute({ children }: { children: React.ReactNode }) {
   if (showLoader) {
     return (
       <FancyLoader
-        message="Preparando a entrada…"
+        message="Abrindo os portões da Videira"
         tips={[
-          "Verificando suas credenciais…",
-          "Abençoando a sessão 🙌",
-          "Quase lá…",
+          "Conferindo seu nome no Livro da Vida digital…",
+          "Polindo o cálice da sessão 🙌",
+          "Chamando os levitas da autenticação…",
         ]}
       />
     );

--- a/src/components/FancyLoader.tsx
+++ b/src/components/FancyLoader.tsx
@@ -13,8 +13,8 @@ export default function FancyLoader({
     tips.length > 0 ? tips[Math.floor(Date.now() / 3000) % tips.length] : "";
 
   return (
-    <div className="fixed inset-0 z-[60] grid place-items-center bg-gradient-to-br from-background via-background to-primary/10">
-      <div className="relative w-full max-w-sm px-6 py-8 rounded-2xl border bg-background/80 backdrop-blur shadow-[0_0_40px_-10px_theme(colors.primary/50%)]">
+    <div className="fixed inset-0 z-[60] grid place-items-center bg-gradient-to-br from-background via-background to-primary/10 px-4">
+      <div className="relative w-full max-w-sm px-6 py-8 rounded-2xl border bg-background/85 backdrop-blur shadow-[0_0_40px_-10px_theme(colors.primary/50%)]">
         {/* orbit animation */}
         <div className="absolute -top-8 left-1/2 -translate-x-1/2">
           <div className="relative w-20 h-20">

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -15,7 +15,7 @@ export function DashboardLayout() {
         <Sidebar />
         <div className="flex-1 flex flex-col">
           <Header />
-          <main className="flex-1 p-6">
+          <main className="flex-1 p-4 sm:p-6">
             <Outlet />
           </main>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,20 +30,20 @@ export function Header() {
     .toUpperCase();
 
   return (
-    <header className="h-16 border-b bg-card flex items-center justify-between px-6">
-      <div className="flex items-center gap-4">
+    <header className="h-16 border-b bg-card flex items-center justify-between px-4 sm:px-6">
+      <div className="flex items-center gap-3 sm:gap-4">
         <SidebarTrigger />
         <div>
-          <h1 className="text-lg font-semibold text-foreground">
+          <h1 className="text-base sm:text-lg font-semibold text-foreground">
             Sistema Videira São Miguel
           </h1>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-xs sm:text-sm text-muted-foreground">
             {roleNames[user.role]} - {user.name}
           </p>
         </div>
       </div>
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-2 sm:gap-4">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" className="relative h-10 w-10 rounded-full">

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -46,7 +46,16 @@ export function Auth() {
   };
 
   if (showLoader) {
-    return <FancyLoader tip="Sincronizando com o servidor…" />;
+    return (
+      <FancyLoader
+        message="Aquecendo o coração da Videira"
+        tips={[
+          "Conferindo se o seu login está no rol dos santos digitais…",
+          "Chamando Gabriel pra guardar a senha…",
+          "Espremendo uvas fresquinhas pra sessão começar!",
+        ]}
+      />
+    );
   }
 
   return (

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -19,7 +19,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { Grape } from 'lucide-react';
+import FancyLoader from '@/components/FancyLoader';
 import { CellReport as CellReportType } from '@/types/church';
 
 interface SimpleUser {
@@ -38,56 +38,6 @@ function linearRegressionForecast(values: number[]): number | null {
   const intercept = sumY / n - slope * (sumX / n);
   const nextX = n + 1;
   return Math.round(intercept + slope * nextX);
-}
-
-/** Overlay de carregamento interativo (bloqueia cliques) */
-function LoadingOverlay({ tip }: { tip?: string }) {
-  const tips = [
-    'Espremendo uvas…',
-    'Organizando as células…',
-    'Contando membros…',
-    'Aquecendo o coração ❤️‍🔥…',
-    'Alinhando relatórios…',
-  ];
-  const safeTip = tip ?? tips[Math.floor((Date.now() / 1000) % tips.length)];
-
-  return (
-    <div
-      className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-center justify-center pointer-events-auto"
-      role="alert"
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <div className="relative w-[90%] max-w-sm rounded-2xl border bg-card shadow-xl p-6 text-center">
-        <div className="mx-auto w-16 h-16 rounded-full bg-gradient-to-br from-primary to-fuchsia-600 flex items-center justify-center shadow-lg animate-pulse">
-          <Grape className="w-8 h-8 text-white" />
-        </div>
-
-        <div className="mt-4 text-sm text-muted-foreground">{safeTip}</div>
-
-        {/* Pontinhos pulando */}
-        <div className="mt-3 flex items-center justify-center gap-1">
-          <span className="w-2 h-2 rounded-full bg-primary/80 animate-bounce [animation-delay:-0.3s]" />
-          <span className="w-2 h-2 rounded-full bg-primary/80 animate-bounce [animation-delay:-0.15s]" />
-          <span className="w-2 h-2 rounded-full bg-primary/80 animate-bounce" />
-        </div>
-
-        {/* Barra de progresso falsa só pra vibe */}
-        <div className="mt-5 h-2 w-full bg-muted rounded-full overflow-hidden">
-          <div className="h-full w-1/3 bg-gradient-to-r from-primary to-fuchsia-600 animate-[loading_1.2s_ease-in-out_infinite]" />
-        </div>
-
-        {/* keyframes inline via Tailwind arbitrary value */}
-        <style>{`
-          @keyframes loading {
-            0%   { transform: translateX(-100%); }
-            50%  { transform: translateX(50%);   }
-            100% { transform: translateX(200%);  }
-          }
-        `}</style>
-      </div>
-    </div>
-  );
 }
 
 export function Statistics() {
@@ -269,22 +219,31 @@ export function Statistics() {
     );
   }
 
+  if (loading) {
+    return (
+      <FancyLoader
+        message="Interpretando os números do Reino"
+        tips={[
+          'Afiando a pena dos escribas para escrever o relatório…',
+          'Contando os peixinhos multiplicados nas células…',
+          'Pedindo sabedoria a Salomão para ler os gráficos…',
+        ]}
+      />
+    );
+  }
+
   const totalPeople = membersCount + visitorsCount;
 
   return (
-    <div className="space-y-8 animate-fade-in relative">
-      {/* Overlay bloqueador */}
-      {loading && <LoadingOverlay />}
-
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <h1 className="text-3xl font-bold text-foreground">Estatísticas</h1>
-        <div className="flex flex-col md:flex-row gap-4">
+    <div className="space-y-10 animate-fade-in pb-16">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <h1 className="text-2xl md:text-3xl font-bold text-foreground">Estatísticas</h1>
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
           <Select
             value={filterType}
             onValueChange={(v: 'geral' | 'discipulador' | 'lider') => setFilterType(v)}
-            disabled={loading}
           >
-            <SelectTrigger className="w-[180px]">
+            <SelectTrigger className="w-full sm:w-[200px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -300,9 +259,8 @@ export function Statistics() {
             <Select
               value={selectedDiscipulador}
               onValueChange={setSelectedDiscipulador}
-              disabled={loading}
             >
-              <SelectTrigger className="w-[200px]">
+              <SelectTrigger className="w-full sm:w-[220px]">
                 <SelectValue placeholder="Selecione" />
               </SelectTrigger>
               <SelectContent>
@@ -319,9 +277,8 @@ export function Statistics() {
             <Select
               value={selectedLeader}
               onValueChange={setSelectedLeader}
-              disabled={loading}
             >
-              <SelectTrigger className="w-[200px]">
+              <SelectTrigger className="w-full sm:w-[220px]">
                 <SelectValue placeholder="Selecione" />
               </SelectTrigger>
               <SelectContent>
@@ -334,8 +291,8 @@ export function Statistics() {
             </Select>
           )}
 
-          <Select value={chartMode} onValueChange={(v: 'mensal' | 'semanal') => setChartMode(v)} disabled={loading}>
-            <SelectTrigger className="w-[150px]">
+          <Select value={chartMode} onValueChange={(v: 'mensal' | 'semanal') => setChartMode(v)}>
+            <SelectTrigger className="w-full sm:w-[180px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -365,7 +322,7 @@ export function Statistics() {
         </CardContent>
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
         <Card className="hover:grape-glow transition-smooth">
           <CardHeader>
             <CardTitle>Membros</CardTitle>

--- a/src/pages/cursos/CourseAdmin.tsx
+++ b/src/pages/cursos/CourseAdmin.tsx
@@ -69,9 +69,9 @@ type Payment = {
 };
 
 const tips = [
-  '“Ensina a criança no caminho…” (Pv 22:6)',
-  '“O obreiro é digno do seu salário.” (Lc 10:7)',
-  '“Fazei tudo com decência e ordem.” (1Co 14:40)',
+  'Acertando a planilha dos cursos como Neemias ajustou os muros…',
+  'Conferindo o dízimo das apostilas e o pãozinho do intervalo…',
+  'Chamando os levitas para tocar enquanto você lança presenças…',
 ];
 
 export default function CourseAdmin() {
@@ -150,11 +150,13 @@ export default function CourseAdmin() {
           .order("registration_date", { ascending: false }),
       ]);
 
-      setSubjects((subs ?? []) as any);
-      setRegistrations((regs ?? []) as any);
+      const subjectRows = (subs as Subject[] | null) ?? [];
+      const registrationRows = (regs as Registration[] | null) ?? [];
+      setSubjects(subjectRows.map((item) => item));
+      setRegistrations(registrationRows.map((item) => item));
 
       // payments de todas regs desse curso
-      const regIds = (regs ?? []).map((r: any) => r.id);
+      const regIds = registrationRows.map((r) => r.id);
       if (regIds.length) {
         const { data: pays } = await supabase
           .from("course_payments")
@@ -345,20 +347,25 @@ export default function CourseAdmin() {
   }
 
   if (loading) {
-    return <FancyLoader message="Preparando Administração de Cursos" tips={tips} />;
+    return (
+      <FancyLoader
+        message="Organizando o QG dos cursos"
+        tips={tips}
+      />
+    );
   }
 
   return (
-    <div className="space-y-8 animate-fade-in">
-      <div className="flex flex-col md:flex-row md:items-end gap-4">
+    <div className="space-y-8 animate-fade-in pb-12">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div className="flex-1">
-          <h1 className="text-3xl font-bold">Trilho do Vencedor — Administração</h1>
-          <p className="text-muted-foreground">Gerencie matérias, chamadas e pagamentos</p>
+          <h1 className="text-2xl md:text-3xl font-bold">Trilho do Vencedor — Administração</h1>
+          <p className="text-sm md:text-base text-muted-foreground">Gerencie matérias, chamadas e pagamentos</p>
         </div>
 
-        <div className="flex gap-3">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
           <Select value={courseId} onValueChange={(v) => { setCourseId(v); setSubjectId(""); }}>
-            <SelectTrigger className="w-[260px]">
+            <SelectTrigger className="w-full sm:w-[260px]">
               <SelectValue placeholder="Selecione o curso (CTL ou Maturidade)" />
             </SelectTrigger>
             <SelectContent>
@@ -370,7 +377,7 @@ export default function CourseAdmin() {
 
           {courseId && (
             <Select value={subjectId} onValueChange={setSubjectId}>
-              <SelectTrigger className="w-[260px]">
+              <SelectTrigger className="w-full sm:w-[260px]">
                 <SelectValue placeholder="Matéria" />
               </SelectTrigger>
               <SelectContent>
@@ -395,7 +402,7 @@ export default function CourseAdmin() {
         {/* --- MATÉRIAS --- */}
         <TabsContent value="subjects">
           <Card className="hover:grape-glow transition-smooth">
-            <CardHeader className="flex flex-row items-center justify-between">
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <CardTitle className="flex items-center gap-2">
                 <GraduationCap className="w-5 h-5 text-primary" />
                 Matérias do Curso
@@ -405,7 +412,7 @@ export default function CourseAdmin() {
                 <DialogTrigger asChild>
                   <Button disabled={!courseId}><Plus className="w-4 h-4 mr-1" /> Nova Matéria</Button>
                 </DialogTrigger>
-                <DialogContent>
+                <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
                   <DialogHeader><DialogTitle>Adicionar Matéria</DialogTitle></DialogHeader>
                   <div className="space-y-3">
                     <div>
@@ -437,24 +444,26 @@ export default function CourseAdmin() {
               ) : subjects.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground">Nenhuma matéria cadastrada.</div>
               ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Título</TableHead>
-                      <TableHead>Professor</TableHead>
-                      <TableHead>Desde</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {subjects.map((s) => (
-                      <TableRow key={s.id}>
-                        <TableCell>{s.title}</TableCell>
-                        <TableCell>{s.teacher?.name ?? "—"}</TableCell>
-                        <TableCell>{s.created_at ? new Date(s.created_at).toLocaleDateString("pt-BR") : "—"}</TableCell>
+                <div className="overflow-x-auto">
+                  <Table className="min-w-[620px]">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Título</TableHead>
+                        <TableHead>Professor</TableHead>
+                        <TableHead>Desde</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {subjects.map((s) => (
+                        <TableRow key={s.id}>
+                          <TableCell>{s.title}</TableCell>
+                          <TableCell>{s.teacher?.name ?? "—"}</TableCell>
+                          <TableCell>{s.created_at ? new Date(s.created_at).toLocaleDateString("pt-BR") : "—"}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
               )}
             </CardContent>
           </Card>
@@ -463,7 +472,7 @@ export default function CourseAdmin() {
         {/* --- CHAMADA --- */}
         <TabsContent value="attendance">
           <Card className="hover:grape-glow transition-smooth">
-            <CardHeader className="flex flex-row items-center justify-between">
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <CardTitle className="flex items-center gap-2">
                 <Users className="w-5 h-5 text-primary" /> Chamada
               </CardTitle>
@@ -482,7 +491,7 @@ export default function CourseAdmin() {
                   <DialogTrigger asChild>
                     <Button><Plus className="w-4 h-4 mr-1" /> Nova Aula</Button>
                   </DialogTrigger>
-                  <DialogContent>
+                <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
                     <DialogHeader><DialogTitle>Nova Aula</DialogTitle></DialogHeader>
                     <div className="space-y-3">
                       <Label>Data da Aula</Label>
@@ -500,8 +509,8 @@ export default function CourseAdmin() {
               ) : (
                 <>
                   {/* cabeçalho com todas as datas/aulas */}
-                  <div className="overflow-auto">
-                    <Table>
+                  <div className="overflow-x-auto">
+                    <Table className="min-w-[780px]">
                       <TableHeader>
                         <TableRow>
                           <TableHead>Aluno</TableHead>
@@ -587,53 +596,55 @@ export default function CourseAdmin() {
               ) : registrations.length === 0 ? (
                 <p className="text-muted-foreground">Nenhuma matrícula encontrada neste curso.</p>
               ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Aluno</TableHead>
-                      <TableHead>Último Pagamento</TableHead>
-                      <TableHead>Total Pago</TableHead>
-                      <TableHead className="text-right">Ações</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {registrations.map((r) => {
-                      const myPays = payments.filter((p) => p.registration_id === r.id);
-                      const total = myPays.reduce((s, p) => s + Number(p.amount || 0), 0);
-                      const last = myPays[0]?.paid_on;
-                      return (
-                        <TableRow key={r.id}>
-                          <TableCell className="font-medium">{r.member?.name ?? r.member_id}</TableCell>
-                          <TableCell>{last ? new Date(last).toLocaleDateString("pt-BR") : "—"}</TableCell>
-                          <TableCell>R$ {total.toFixed(2)}</TableCell>
-                          <TableCell className="text-right">
-                            <Dialog open={openNewPayment === r.id} onOpenChange={(o) => setOpenNewPayment(o ? r.id : null)}>
-                              <DialogTrigger asChild>
-                                <Button size="sm" variant="outline"><DollarSign className="w-4 h-4 mr-1" /> Registrar</Button>
-                              </DialogTrigger>
-                              <DialogContent>
-                                <DialogHeader><DialogTitle>Novo Pagamento — {r.member?.name}</DialogTitle></DialogHeader>
-                                <div className="space-y-3">
-                                  <div>
-                                    <Label>Valor (R$)</Label>
-                                    <Input value={paymentAmount} onChange={(e) => setPaymentAmount(e.target.value)} />
+                <div className="overflow-x-auto">
+                  <Table className="min-w-[640px]">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Aluno</TableHead>
+                        <TableHead>Último Pagamento</TableHead>
+                        <TableHead>Total Pago</TableHead>
+                        <TableHead className="text-right">Ações</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {registrations.map((r) => {
+                        const myPays = payments.filter((p) => p.registration_id === r.id);
+                        const total = myPays.reduce((s, p) => s + Number(p.amount || 0), 0);
+                        const last = myPays[0]?.paid_on;
+                        return (
+                          <TableRow key={r.id}>
+                            <TableCell className="font-medium">{r.member?.name ?? r.member_id}</TableCell>
+                            <TableCell>{last ? new Date(last).toLocaleDateString("pt-BR") : "—"}</TableCell>
+                            <TableCell>R$ {total.toFixed(2)}</TableCell>
+                            <TableCell className="text-right">
+                              <Dialog open={openNewPayment === r.id} onOpenChange={(o) => setOpenNewPayment(o ? r.id : null)}>
+                                <DialogTrigger asChild>
+                                  <Button size="sm" variant="outline"><DollarSign className="w-4 h-4 mr-1" /> Registrar</Button>
+                                </DialogTrigger>
+                                <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-md">
+                                  <DialogHeader><DialogTitle>Novo Pagamento — {r.member?.name}</DialogTitle></DialogHeader>
+                                  <div className="space-y-3">
+                                    <div>
+                                      <Label>Valor (R$)</Label>
+                                      <Input value={paymentAmount} onChange={(e) => setPaymentAmount(e.target.value)} />
+                                    </div>
+                                    <div>
+                                      <Label>Data</Label>
+                                      <Input type="date" value={paymentDate} onChange={(e) => setPaymentDate(e.target.value)} />
+                                    </div>
+                                    <Button className="w-full" onClick={addPayment} disabled={!paymentDate || !Number(paymentAmount)}>
+                                      Salvar Pagamento
+                                    </Button>
                                   </div>
-                                  <div>
-                                    <Label>Data</Label>
-                                    <Input type="date" value={paymentDate} onChange={(e) => setPaymentDate(e.target.value)} />
-                                  </div>
-                                  <Button className="w-full" onClick={addPayment} disabled={!paymentDate || !Number(paymentAmount)}>
-                                    Salvar Pagamento
-                                  </Button>
-                                </div>
-                              </DialogContent>
-                            </Dialog>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+                                </DialogContent>
+                              </Dialog>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
               )}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- refresh fancy loader messaging across route guards and feature screens
- tighten course management flows with typed data loading and mobile-friendly layout tweaks
- improve dashboard and statistics loaders while keeping tables scrollable on small devices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c880bed7c48328bca983a3612312a7